### PR TITLE
Add snapcraft.yaml defining the GDC snap package and its components

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,59 @@
+name: gdc
+version: 7.3.0
+summary: D compiler based on the GCC backend
+description: |
+    GDC is a compiler for the D programming language, which
+    integrates the official DMD D2 compiler frontend with
+    GCC.  The gdmd wrapper command is also included, which
+    provides a DMD-like command-line interface for GDC.
+
+confinement: classic
+grade: devel
+
+apps:
+  gdc:
+    command: bin/gdc
+  gdmd:
+    command: bin/gdmd
+
+parts:
+  gdc:
+    source: https://github.com/D-Programming-GDC/GDC.git
+    source-branch: gdc-7
+    plugin: dump
+    stage:
+    - -*
+    prime:
+    - -*
+
+  gdmd:
+    source: https://github.com/D-Programming-GDC/GDMD.git
+    source-branch: master
+    plugin: dump
+    organize:
+      dmd-script: bin/gdmd
+      dmd-script.1: man/man1/gdmd.1
+
+  gcc:
+    source: ftp://ftp.mirrorservice.org/sites/sourceware.org/pub/gcc/releases/gcc-7.3.0/gcc-7.3.0.tar.gz
+    source-checksum: sha512/4e203f4ea5e8713e7b0e3d2a269f7a54f6d1074d572b93d39ed6961c82b3c310f389d7f78494f58309b7436d1e0744eba06c22a24747000dfd84e2b4376cbf73
+    plugin: autotools
+    configflags:
+    - --enable-languages=d,lto
+    - --enable-checking=release
+    - --enable-default-pie
+    - --disable-bootstrap
+    prepare: |
+      ../../gdc/build/setup-gcc.sh .
+    build-packages:
+    - g++
+    - g++-multilib
+    - libc6-dev
+    - libc6-dev-i386
+    - libc6-dev-x32
+    - libgmp3-dev
+    - libmpc-dev
+    - libmpfr-dev
+    - patch
+    after:
+    - gdc


### PR DESCRIPTION
The GDC package uses `classic` confinement to ensure that it can access the resources of the host system it is installed on, e.g. libc and any development libraries against which compiled code needs to link.

The `gdc` command is exposed together with the `gdmd` DMD-alike wrapper script (downloaded in a separate part).

The build itself is managed via the `gcc` part: a `prepare` scriptlet runs GDC's `setup-gcc.sh` script, and then we run the regular GCC build via the `autotools` plugin, configured to enable D and LTO.